### PR TITLE
Fix time reservation logic

### DIFF
--- a/repository/request_repository.py
+++ b/repository/request_repository.py
@@ -94,6 +94,7 @@ class RequestRepository:
             requests = [row[0] for row in rows]
 
             for request in requests:
-                if request.response != 0:
+                if request.response in (0, 1):
                     return True
+
             return False

--- a/services/mentor_time_service.py
+++ b/services/mentor_time_service.py
@@ -132,5 +132,7 @@ class MentorTimeService:
     async def check_time_reservation(self, mentor_id: UUID, time: DateTime) -> bool:
         """
         Проверка занятости времени. True -- занято, False -- не занято.
+        Занятым считается время с запросами в статусе ``0`` (ожидает ответа)
+        или ``1`` (принят).
         """
         return await self.request_repository.check_time_reservation(time=time, mentor_id=mentor_id)


### PR DESCRIPTION
## Summary
- adjust `check_time_reservation` logic to treat pending and accepted requests as busy
- clarify docstring for mentor time reservation check