### PR TITLE
Improve request counting response

### DIFF
--- a/presentations/fastapi_app.py
+++ b/presentations/fastapi_app.py
@@ -86,7 +86,9 @@ async def lifespan(app: FastAPI):
 
     # Одобряем запрос и проводим проверку
     try:
-        logger.info(f"Mentor has: {await mentor_service.count_requests(mentor_id)} requests")
+        req_counts = await mentor_service.count_requests(mentor_id)
+        logger.info(
+            f"Mentor has {req_counts['call_requests']} call requests and {req_counts['message_requests']} message requests")
     except ValueError as e:
         logger.error(f"Can't find that mentor: {e}")
 

--- a/presentations/routers/mentor_router.py
+++ b/presentations/routers/mentor_router.py
@@ -220,8 +220,8 @@ async def count_by_id(mentor_id: UUID, user_id: UUID = Depends(extract_user_id))
             raise HTTPException(status_code=404, detail="Хз что не так, если честно")
 
         return CountMentorRequestByIdGetResponse(
-            call_requests=mentor_requests_cnt[0],
-            message_requests=mentor_requests_cnt[1],
+            call_requests=mentor_requests_cnt["call_requests"],
+            message_requests=mentor_requests_cnt["message_requests"],
         )
     except HTTPException:
         raise

--- a/services/mentor_service.py
+++ b/services/mentor_service.py
@@ -66,15 +66,24 @@ class MentorService:
     async def count_requests(self, mentor_id: UUID) -> dict:
         """
         Возвращает количество неотвеченных запросов.
+
+        Возвращает словарь с ключами `call_requests` и `message_requests`.
         """
         mentor_requests = await self.request_repository.get_all_requests_by_mentor_id(mentor_id)
 
-        call_type_count = defaultdict(int)
+        call_requests = 0
+        message_requests = 0
         for request in mentor_requests:
             if request.response == 0:
-                call_type_count[request.call_type] += 1
+                if request.call_type == 0:
+                    call_requests += 1
+                else:
+                    message_requests += 1
 
-        return dict(call_type_count)
+        return {
+            "call_requests": call_requests,
+            "message_requests": message_requests,
+        }
 
     async def get_requests(self, mentor_id: UUID) -> List[Request]:
         """


### PR DESCRIPTION
## Summary
- enhance `MentorService.count_requests` to return a dictionary with `call_requests` and `message_requests`
- use new keys in `mentor_router` to avoid index-based access
- update log message in demo FastAPI app