### PR TITLE
Handle mentor request cancellation

### DIFF
--- a/persistent/db/request.py
+++ b/persistent/db/request.py
@@ -17,6 +17,6 @@ class Request(Base, WithId):
     #if call_type == 0:
     call_time = Column(DateTime, nullable=True)
 
-    response = Column(Integer, nullable=False, default=0) # 0 -- not answered, 1-- yes, -1 -- no
+    response = Column(Integer, nullable=False, default=0) # 0 -- not answered, 1 -- accepted, -1 -- rejected, 2 -- cancelled
     mentor = relationship("Mentor", back_populates="requests")
 

--- a/presentations/routers/mentor_router.py
+++ b/presentations/routers/mentor_router.py
@@ -349,3 +349,19 @@ async def respond_to_request(request_id: UUID, req: MentorRespondRequest, user_i
     except Exception as e:
         logger.error(f"Error responding to request: {e}")
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@mentor_router.patch("/request/{request_id}/cancel")
+async def cancel_request(request_id: UUID, user_id: UUID = Depends(extract_user_id)):
+    """
+    Отменить ранее подтверждённую заявку.
+    Слот свободного времени восстанавливается.
+    Требуется авторизация (JWT).
+    """
+    try:
+        logger.info(f"Mentor {user_id} cancels request {request_id}")
+        await mentor_service.cancel_request(user_id, request_id)
+        return {"status": "ok"}
+    except Exception as e:
+        logger.error(f"Error cancelling request: {e}")
+        raise HTTPException(status_code=400, detail=str(e))

--- a/repository/request_repository.py
+++ b/repository/request_repository.py
@@ -84,6 +84,10 @@ class RequestRepository:
         return row[0]
 
     async def check_time_reservation(self, mentor_id: UUID, time: datetime) -> bool:
+        """Return True if there is a pending or accepted request at this time.
+
+        Requests with status ``2`` (cancelled) do not count as a reservation.
+        """
         stmt = select(Request).where(cast("ColumnElement[bool]", Request.call_time == time),
                                      cast("ColumnElement[bool]", Request.mentor_id == mentor_id))
 

--- a/services/mentor_time_service.py
+++ b/services/mentor_time_service.py
@@ -135,6 +135,6 @@ class MentorTimeService:
         """
         Проверка занятости времени. True -- занято, False -- не занято.
         Занятым считается время с запросами в статусе ``0`` (ожидает ответа)
-        или ``1`` (принят).
+        или ``1`` (принят). Отменённые запросы (статус ``2``) свободны.
         """
         return await self.request_repository.check_time_reservation(time=time, mentor_id=mentor_id)


### PR DESCRIPTION
## Summary
- mark request status `2` as cancelled
- remove mentor time slot when accepting a request
- add `cancel_request` for mentors to restore their slot
- document cancelled status handling