### PR TITLE
Include extended mentor fields in API responses

### DIFF
--- a/presentations/routers/mentor_router.py
+++ b/presentations/routers/mentor_router.py
@@ -30,6 +30,21 @@ class MentorDto(BaseModel):
     work: Optional[str] = None
 
 
+def build_mentor_dto(mentor) -> MentorDto:
+    """Convert mentor ORM instance to MentorDto with optional fields."""
+    return MentorDto(
+        id=mentor.id,
+        telegram_id=mentor.telegram_id,
+        name=mentor.name,
+        info=mentor.info,
+        specification=getattr(mentor, "specification", None),
+        role=getattr(mentor, "role", None),
+        experience_periods=getattr(mentor, "experience_periods", None),
+        hackathons=getattr(mentor, "hackathons", None),
+        work=getattr(mentor, "work", None),
+    )
+
+
 class RequestDto(BaseModel):
     id: UUID
     call_type: bool
@@ -112,16 +127,7 @@ async def get_all(user_id: UUID = Depends(extract_user_id)):
         mentors = await mentor_service.get_all_mentors()
 
         return MentorGetAllResponse(
-            mentors=[MentorDto(id=mentor.id,
-                               telegram_id=mentor.telegram_id,
-                               name=mentor.name,
-                               info=mentor.info,
-                               specification=mentor.specification,
-                               role=getattr(mentor, "role", None),
-                               experience_periods=getattr(mentor, "experience_periods", None),
-                               hackathons=getattr(mentor, "hackathons", None),
-                               work=getattr(mentor, "work", None))
-                     for mentor in mentors]
+            mentors=[build_mentor_dto(mentor) for mentor in mentors]
         )
     except HTTPException:
         raise
@@ -173,15 +179,16 @@ async def get_by_id(mentor_id: UUID, user_id: UUID = Depends(extract_user_id)):
             logger.warning(f"Mentor with ID {mentor_id} not found")
             raise HTTPException(status_code=404, detail="Ментор не найден")
 
+        dto = build_mentor_dto(mentor)
         return GetMentorByIdGetResponse(
-            telegram_id=mentor.telegram_id,
-            name=mentor.name,
-            info=mentor.info,
-            specification=mentor.specification,
-            role=getattr(mentor, "role", None),
-            experience_periods=getattr(mentor, "experience_periods", None),
-            hackathons=getattr(mentor, "hackathons", None),
-            work=getattr(mentor, "work", None)
+            telegram_id=dto.telegram_id,
+            name=dto.name,
+            info=dto.info,
+            specification=dto.specification,
+            role=dto.role,
+            experience_periods=dto.experience_periods,
+            hackathons=dto.hackathons,
+            work=dto.work,
         )
     except HTTPException:
         raise
@@ -208,15 +215,16 @@ async def get_by_tg_id(telegram_id: str, user_id: UUID = Depends(extract_user_id
             logger.warning(f"Mentor with telegram ID {telegram_id} not found")
             raise HTTPException(status_code=404, detail="Ментор не найден")
 
+        dto = build_mentor_dto(mentor)
         return GetMentorByTelegramIdGetResponse(
-            telegram_id=mentor.telegram_id,
-            name=mentor.name,
-            info=mentor.info,
-            specification=mentor.specification,
-            role=getattr(mentor, "role", None),
-            experience_periods=getattr(mentor, "experience_periods", None),
-            hackathons=getattr(mentor, "hackathons", None),
-            work=getattr(mentor, "work", None)
+            telegram_id=dto.telegram_id,
+            name=dto.name,
+            info=dto.info,
+            specification=dto.specification,
+            role=dto.role,
+            experience_periods=dto.experience_periods,
+            hackathons=dto.hackathons,
+            work=dto.work,
         )
     except HTTPException:
         raise
@@ -326,16 +334,7 @@ async def search_by_name(name: str, user_id: UUID = Depends(extract_user_id)):
         logger.info(f"User {user_id} searching mentors by name: {name}")
         mentors = await mentor_service.find_mentors_by_name(name)
         return MentorGetAllResponse(
-            mentors=[MentorDto(id=mentor.id,
-                               telegram_id=mentor.telegram_id,
-                               name=mentor.name,
-                               info=mentor.info,
-                               specification=mentor.specification,
-                               role=getattr(mentor, "role", None),
-                               experience_periods=getattr(mentor, "experience_periods", None),
-                               hackathons=getattr(mentor, "hackathons", None),
-                               work=getattr(mentor, "work", None))
-                     for mentor in mentors]
+            mentors=[build_mentor_dto(mentor) for mentor in mentors]
         )
     except Exception as e:
         logger.error(f"Error searching mentors by name: {e}")
@@ -351,16 +350,7 @@ async def search_by_role(role: str, user_id: UUID = Depends(extract_user_id)):
         logger.info(f"User {user_id} searching mentors by role: {role}")
         mentors = await mentor_service.find_mentors_by_specification(role)
         return MentorGetAllResponse(
-            mentors=[MentorDto(id=mentor.id,
-                               telegram_id=mentor.telegram_id,
-                               name=mentor.name,
-                               info=mentor.info,
-                               specification=mentor.specification,
-                               role=getattr(mentor, "role", None),
-                               experience_periods=getattr(mentor, "experience_periods", None),
-                               hackathons=getattr(mentor, "hackathons", None),
-                               work=getattr(mentor, "work", None))
-                     for mentor in mentors]
+            mentors=[build_mentor_dto(mentor) for mentor in mentors]
         )
     except Exception as e:
         logger.error(f"Error searching mentors by role: {e}")


### PR DESCRIPTION
## Summary
- refactor mentor-to-DTO conversion via helper
- ensure new fields `role`, `experience_periods`, `hackathons`, and `work` are returned for mentors